### PR TITLE
Fix hook infinite loop

### DIFF
--- a/src/poc-code/console-mount/src/components/plugins/IncludePlugins.tsx
+++ b/src/poc-code/console-mount/src/components/plugins/IncludePlugins.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import noop from 'lodash/noop';
 import { initConsolePlugins } from '@console/dynamic-plugin-sdk/src/runtime/plugin-init';
 import { /* ActivePlugin, */ PluginStore } from '@console/plugin-sdk';
 import { useReduxStore } from '../../redux';
@@ -6,11 +7,11 @@ import { getEnabledDynamicPluginNames } from './utils';
 import { loadDynamicPlugin } from '@console/dynamic-plugin-sdk/src/runtime/plugin-loader';
 
 type PluginProps = {
-  enabledPlugins?: any;
+  enabledPlugins?: string[];
   onPluginRegister?: Function;
 };
 
-const IncludePlugins = ({ enabledPlugins, onPluginRegister = () => undefined }: PluginProps) => {
+const IncludePlugins = ({ enabledPlugins, onPluginRegister = noop }: PluginProps) => {
   const [pluginStore, setPluginStore] = React.useState<PluginStore>();
   const store = useReduxStore();
 


### PR DESCRIPTION
With the lint fix, I didn't run the code... turns out I accidentally added an infinite loop as an undefined variable was given a new function every time and then made a dependency of a useEffect hook -- which triggered a re-render and then a new function. Fixed with `noop` from lodash.

Also altered a type from `any` to `string[]`